### PR TITLE
Lift INS and STR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_FLAGS "-Werror -Wall -Wextra -Wno-parentheses")
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 17)
 
 find_library(BINJA_CORE_LIBRARY
     NAMES binaryninjacore libbinaryninjacore.so.1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.1)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_FLAGS "-Werror -Wall -Wextra -Wno-parentheses")
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_library(BINJA_CORE_LIBRARY
     NAMES binaryninjacore libbinaryninjacore.so.1

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Binary Ninja IL lifting extensions for AArch64
 - [x] MRS
 - [x] MSR
 - [x] FMOV
+- [x] INS
+- [x] STR (vector)
 - ... (make a GitHub issue)
 
 As with all AArch64 hobby projects, correctness is not guaranteed. Use this software at your own risk.

--- a/aarch64_extension.cpp
+++ b/aarch64_extension.cpp
@@ -23,6 +23,49 @@ template <typename T> inline T Ones(size_t count) {
   }
 }
 
+/*
+ * Given a Vector Arrangement Specifier, return the _element_ size to be
+ * operated on.
+ * Verify that the VAS is indeed valid before calling this function.
+ */
+static size_t vectorElementSize(enum arm64_vas vas) {
+  switch (vas) {
+  case ARM64_VAS_16B:
+  case ARM64_VAS_8B:
+#ifdef CAPSTONE_NEXT
+  case ARM64_VAS_4B:
+  case ARM64_VAS_1B:
+#endif /* #ifdef CAPSTONE_NEXT */
+    return (1);
+  case ARM64_VAS_8H:
+  case ARM64_VAS_4H:
+#ifdef CAPSTONE_NEXT
+  case ARM64_VAS_2H:
+  case ARM64_VAS_1H:
+#endif /* #ifdef CAPSTONE_NEXT */
+    return (2);
+  case ARM64_VAS_4S:
+  case ARM64_VAS_2S:
+#ifdef CAPSTONE_NEXT
+  case ARM64_VAS_1S:
+#endif /* #ifdef CAPSTONE_NEXT */
+    return (4);
+  case ARM64_VAS_2D:
+  case ARM64_VAS_1D:
+    return (8);
+  case ARM64_VAS_1Q:
+    return (16);
+  default:
+    /*
+     * If we've called this with ARM64_VAS_INVALID we're missing new enum
+     * members, we need to fix the caller.
+     */
+    LogError("%s() called with invalid VAS %d", __FUNCTION__, vas);
+    assert(false);
+    __builtin_unreachable();
+  }
+}
+
 class Disassembler {
 private:
   csh mCapstone{};
@@ -140,6 +183,111 @@ private:
       }
     }
     return 0;
+  }
+
+  ExprId liftMemOperand(LowLevelILFunction& il, cs_arm64_op& op) {
+    uint32_t Rn = this->m_base->GetRegisterByName(
+        cs_reg_name(disassembler.Get(), op.mem.base));
+    int32_t imm = op.mem.disp;
+
+    size_t Rn_size = this->m_base->GetRegisterInfo(Rn).size;
+
+    assert(8 == Rn_size); /* Otherwise capstone was seriously wrong */
+
+    if (ARM64_REG_INVALID == op.mem.index) {
+      /* No index register, no shifts/extends, just an immediate offset */
+      if (0 != imm) {
+        return il.Add(Rn_size, il.Register(Rn_size, Rn), il.Const(4, imm));
+      } else {
+        return il.Register(Rn_size, Rn);
+      }
+    } else {
+      uint32_t Rm = this->m_base->GetRegisterByName(
+          cs_reg_name(disassembler.Get(), op.mem.index));
+      size_t Rm_size = this->m_base->GetRegisterInfo(Rm).size;
+
+      arm64_shifter shiftType = op.shift.type;
+      unsigned int shiftAmt = op.shift.value;
+
+      arm64_extender extend = op.ext;
+
+      assert(8 == Rm_size || 4 == Rm_size);
+      assert(0 == imm); /* register and immediate offset cannot be combined */
+
+      ExprId disp = il.Register(Rm_size, Rm);
+
+      /*
+       * First switch on extend in case Rm is 4 bytes and must be implicitly
+       * extended to 8 before any shifting.
+       * See the ExtendReg() pseudocode in the manual for this logic.
+       */
+      switch (extend) {
+      case ARM64_EXT_UXTB:
+      case ARM64_EXT_UXTH:
+      case ARM64_EXT_UXTW:
+      case ARM64_EXT_UXTX:
+        disp = il.ZeroExtend(Rn_size, disp);
+        break;
+      case ARM64_EXT_SXTB:
+      case ARM64_EXT_SXTH:
+      case ARM64_EXT_SXTW:
+      case ARM64_EXT_SXTX:
+        disp = il.SignExtend(Rn_size, disp);
+        break;
+      case ARM64_EXT_INVALID:
+        /* No extend */
+        assert(Rn_size == Rm_size);
+        break;
+      default:
+        LogError("Invalid extend type %d", extend);
+        assert(false);
+        __builtin_unreachable();
+      }
+
+      assert(shiftAmt <= 4);
+      switch (shiftType) {
+      case ARM64_SFT_LSL:
+        disp = il.ShiftLeft(Rn_size, disp, il.Const(1, shiftAmt));
+        break;
+      case ARM64_SFT_INVALID:
+        /* No shift */
+        break;
+      case ARM64_SFT_MSL:
+      case ARM64_SFT_LSR:
+      case ARM64_SFT_ASR:
+      case ARM64_SFT_ROR:
+      default:
+        LogError("Invalid shift type %d", shiftType);
+        assert(false);
+        __builtin_unreachable();
+      }
+
+      /* Switch on extend again to do the outer extend */
+      switch (extend) {
+      case ARM64_EXT_UXTB:
+      case ARM64_EXT_UXTH:
+      case ARM64_EXT_UXTW:
+      case ARM64_EXT_UXTX:
+        disp = il.ZeroExtend(Rn_size, disp);
+        break;
+      case ARM64_EXT_SXTB:
+      case ARM64_EXT_SXTH:
+      case ARM64_EXT_SXTW:
+      case ARM64_EXT_SXTX:
+        disp = il.SignExtend(Rn_size, disp);
+        break;
+      case ARM64_EXT_INVALID:
+        /* No extend */
+        assert(Rn_size == Rm_size);
+        break;
+      default:
+        /* Should be caught above first */
+        assert(false);
+        __builtin_unreachable();
+      }
+
+      return il.Add(Rn_size, il.Register(Rn_size, Rn), disp);
+    }
   }
 
 public:
@@ -586,6 +734,135 @@ public:
     return true;
   }
 
+  bool LiftINS(cs_insn* instr, LowLevelILFunction& il) {
+    cs_arm64* detail = &(instr->detail->arm64);
+
+    if (detail->op_count != 2) {
+      return false;
+    }
+
+    if (detail->operands[0].type != ARM64_OP_REG ||
+        -1 == detail->operands[0].vector_index ||
+        ARM64_VAS_INVALID == detail->operands[0].vas ||
+        detail->operands[1].type != ARM64_OP_REG) {
+      return false;
+    }
+
+    uint32_t Rd = this->m_base->GetRegisterByName(
+        cs_reg_name(disassembler.Get(), detail->operands[0].reg));
+    uint32_t Rn = this->m_base->GetRegisterByName(
+        cs_reg_name(disassembler.Get(), detail->operands[1].reg));
+
+    size_t Rn_size = this->m_base->GetRegisterInfo(Rn).size;
+
+    size_t Rd_elem_size = vectorElementSize(detail->operands[0].vas);
+    int Rd_index = detail->operands[0].vector_index;
+    int Rn_index = detail->operands[1].vector_index;
+
+    uint32_t subRd = getVectorSubregister(Rd, Rn_size, Rd_index);
+    if (0 == subRd) {
+      LogError("%#lx: Invalid vector element access in operand 0",
+               instr->address);
+      return false;
+    }
+
+    if (-1 == Rn_index) {
+      /* INS (general) */
+      if (Rd_elem_size != Rn_size) {
+        LogError("%#lx: Operand size mismatch: Vd.Ts size %zu, Rn size %zu",
+                 instr->address, Rd_elem_size, Rn_size);
+        return false;
+      }
+
+      il.AddInstruction(
+          il.SetRegister(Rn_size, subRd, il.Register(Rn_size, Rn)));
+    } else {
+      /* INS (element) */
+
+      if (ARM64_VAS_INVALID == detail->operands[1].vas) {
+        LogError("%#lx: Vector operand 1 missing arrangement specifier",
+                 instr->address);
+        return false;
+      }
+
+      size_t Rn_elem_size = vectorElementSize(detail->operands[1].vas);
+      if (Rd_elem_size != Rn_elem_size) {
+        LogError("%#lx: Vector operand element size mismatch: %zu != %zu",
+                 instr->address, Rd_elem_size, Rn_elem_size);
+        return false;
+      }
+
+      uint32_t subRn = getVectorSubregister(Rn, Rn_size, Rd_index);
+      if (0 == subRn) {
+        LogError("%#lx: Invalid vector element access in operand 1",
+                 instr->address);
+        return false;
+      }
+
+      il.AddInstruction(il.SetRegister(Rd_elem_size, subRd,
+                                       il.Register(Rn_elem_size, subRn)));
+    }
+
+    return true;
+  }
+
+  bool LiftSTR(cs_insn* instr, LowLevelILFunction& il) {
+    cs_arm64* detail = &(instr->detail->arm64);
+
+    if (detail->op_count != 2 && detail->op_count != 3) {
+      return false;
+    }
+
+    if (detail->operands[0].type != ARM64_OP_REG ||
+        detail->operands[1].type != ARM64_OP_MEM) {
+      return false;
+    }
+
+    uint32_t Rt = this->m_base->GetRegisterByName(
+        cs_reg_name(disassembler.Get(), detail->operands[0].reg));
+
+    size_t Rt_size = this->m_base->GetRegisterInfo(Rt).size;
+
+    ExprId address = liftMemOperand(il, detail->operands[1]);
+    ExprId value;
+
+    if (ARM64_REG_WZR == detail->operands[0].reg ||
+        ARM64_REG_XZR == detail->operands[0].reg) {
+      /* The zero register doesn't count */
+      value = il.Const(1, 0);
+    } else {
+      value = il.Register(Rt_size, Rt);
+    }
+
+    il.AddInstruction(il.Store(Rt_size, address, value));
+
+    if (detail->writeback) {
+      /* Lift write-back to base register (Rn) */
+      uint32_t Rn = this->m_base->GetRegisterByName(
+          cs_reg_name(disassembler.Get(), detail->operands[1].mem.base));
+      size_t Rn_size = this->m_base->GetRegisterInfo(Rn).size;
+
+      /* Lift address expr again for writeback */
+      address = liftMemOperand(il, detail->operands[1]);
+
+      if (3 == detail->op_count) {
+        /* Add post-index */
+        if (ARM64_OP_IMM != detail->operands[2].type) {
+          LogError("%#lx: Expected immediate or nothing for operand 2",
+                   instr->address);
+          return false;
+        }
+
+        address =
+            il.Add(Rn_size, address, il.Const(4, detail->operands[2].imm));
+      }
+
+      il.AddInstruction(il.SetRegister(Rn_size, Rn, address));
+    }
+
+    return true;
+  }
+
   bool GetInstructionLowLevelIL(const uint8_t* data, uint64_t addr, size_t& len,
                                 LowLevelILFunction& il) override {
     cs_insn* instr;
@@ -642,6 +919,21 @@ public:
         LogInfo("MSR @ 0x%lx", instr->address);
 #endif
         supported = LiftMSR(instr, il);
+        break;
+      case ARM64_INS_MOV:
+        /* Capstone (sometimes?) uses this alias for INS... */
+        /* fall through, only handles INS-like operands */
+      case ARM64_INS_INS:
+#ifdef AARCH64_TRACE_INSTR
+        LogInfo("INS @ 0x%lx", instr->address);
+#endif
+        supported = LiftINS(instr, il);
+        break;
+      case ARM64_INS_STR:
+#ifdef AARCH64_TRACE_INSTR
+        LogInfo("STR @ 0x%lx", instr->address);
+#endif
+        supported = LiftSTR(instr, il);
         break;
       }
     }

--- a/tdata/fmov.s
+++ b/tdata/fmov.s
@@ -1,5 +1,5 @@
 /*
- * aarch64-linux-gnu-as -mcpu=cortex-a77 fmov.s -o fmov.o
+ * aarch64-linux-gnu-as -mcpu=all fmov.s -o fmov.o
  */
 
 _start:

--- a/tdata/str.s
+++ b/tdata/str.s
@@ -1,0 +1,49 @@
+/*
+ * aarch64-linux-gnu-as -mcpu=all str.s -o str.o
+ */
+
+_start:
+    /* Store vector registers (stack offset) */
+    str     b0, [sp, #0x610]
+    str     h0, [sp, #0x610]
+    str     s0, [sp, #0x610]
+    str     d0, [sp, #0x610]
+    str     q0, [sp, #0x610]
+
+    /* Post-index */
+    str     b0, [x0], #0xf0
+    str     h0, [x0], #0xf0
+    str     s0, [x0], #0xf0
+    str     d0, [x0], #0xf0
+    str     q0, [x0], #0xf0
+
+    /* Pre-index with writeback */
+    str     b0, [x0, #0xfc]!
+    str     h0, [x0, #0xfc]!
+    str     s0, [x0, #0xfc]!
+    str     d0, [x0, #0xfc]!
+    str     q0, [x0, #0xfc]!
+
+    /* Store vector registers (register, no offset) */
+    str     b0, [x0]
+    str     h0, [x0]
+    str     s0, [x0]
+    str     d0, [x0]
+    str     q0, [x0]
+
+    /* Store full-width vector registers */
+/* The manual says this is possible, but GNU as won't assemble it:
+    str     v0, [x0, #0x610]
+    str     v0, [x0]
+*/
+
+    /* Store zero register */
+    str     wzr, [x0]
+    str     xzr, [x0]
+
+    /* Store with shifted index register */
+    str     x0, [x8, x25, lsl #3]
+    str     h0, [x8, x25, lsl #1]
+
+    /* Store with extend? */
+    str     x0, [x8, w25, uxtw #3]

--- a/tdata/str.s
+++ b/tdata/str.s
@@ -16,6 +16,7 @@ _start:
     str     s0, [x0], #0xf0
     str     d0, [x0], #0xf0
     str     q0, [x0], #0xf0
+    str     q0, [x0], #-234
 
     /* Pre-index with writeback */
     str     b0, [x0, #0xfc]!


### PR DESCRIPTION
Only the vector-register versions of STR were unimplemented in Binja, but this implements all versions, because there's no real difference in capstone.

Note INS will not lift at the moment due to aquynh/capstone#1620.